### PR TITLE
Fix docker copy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:0.10
 RUN mkdir -p /app
 WORKDIR /app
 
-COPY package.json /app
+COPY package.json /app/package.json
 RUN npm install
 
 COPY . /app


### PR DESCRIPTION
Tweak COPY path for package.json. Fixes "Service 'web' failed to build: stat /mnt/sda1/var/lib/docker/aufs/mnt/xyz/app/package.json: not a directory".